### PR TITLE
orca: Install python-igraph for trans-abyss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,6 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>" \
 
 # Fix Warning: Some installed formulae are missing dependencies
 RUN brew install isl libpthread-stubs xorg-protocols
+
+# Fix trans-abyss: ImportError: No module named igraph
+RUN pip2 install python-igraph


### PR DESCRIPTION
Fix ImportError: No module named igraph