### PR TITLE
orca-1: Remove htseq

### DIFF
--- a/orca-1/Dockerfile
+++ b/orca-1/Dockerfile
@@ -11,7 +11,6 @@ python-igraph
 RUN pip3 install \
 biopython \
 cwlref-runner \
-htseq \
 pandas \
 pysam \
 pyvcf \


### PR DESCRIPTION
It fails to install with Python 3.7.
See https://github.com/bcgsc/orca/issues/60