### PR TITLE
Remove mysql - due to build error

### DIFF
--- a/orca-0/Dockerfile
+++ b/orca-0/Dockerfile
@@ -25,7 +25,6 @@ less \
 libxml2 \
 matplotlib \
 miller \
-mysql \
 numpy \
 pandoc \
 perl \


### PR DESCRIPTION
`brew install mysql` failing with error:
```
CMake Error at cmake/do_abi_check.cmake:86 (MESSAGE):
  ABI check found difference between
  /tmp/mysql-20190404-31760-1h9gyd3/mysql-8.0.15/include/mysql/services.h.pp
  and /tmp/mysql-20190404-31760-1h9gyd3/mysql-8.0.15/abi_check.out


make[2]: *** [CMakeFiles/abi_check] Error 1
make[2]: Leaving directory `/tmp/mysql-20190404-31760-1h9gyd3/mysql-8.0.15'
make[1]: *** [CMakeFiles/abi_check.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
The `blat` formula was changed upstream to make `mysql` a build dependency, so none of the tools should require `mysql` as a run-time dependency.