### PR TITLE
Add 34 tools to ORCA

### DIFF
--- a/orca-2/Dockerfile
+++ b/orca-2/Dockerfile
@@ -13,10 +13,10 @@ adam \
 adapterremoval \
 afra \
 ale \
-amos \
 andi \
 aragorn \
 arcs \
+arks \
 art \
 artemis \
 ascp \
@@ -30,6 +30,7 @@ bamtools \
 bamutil \
 bandage \
 barrnap \
+bazam \
 bbtools \
 bcalm \
 bcftools \
@@ -53,6 +54,7 @@ bless \
 bonsai \
 bowtie \
 bowtie2 \
+bracken \
 breseq \
 busco \
 bwa

--- a/orca-3/Dockerfile
+++ b/orca-3/Dockerfile
@@ -22,6 +22,7 @@ crumble \
 curl \
 cutadapt \
 daligner \
+das_tool \
 dazz_db \
 delly \
 diamond \
@@ -38,6 +39,7 @@ elph \
 ema \
 emacs \
 emboss \
+epa-ng \
 exabayes \
 exonerate  \
 express \
@@ -55,17 +57,23 @@ fermi-lite \
 fermi2 \
 fermikit \
 figtree \
+filtlong \
 finch-rs \
 flash \
 flex \
+flowcraft \
 flye \
 fqzcomp \
+fraggenescan \
 freebayes \
 freec \
 fsa \
 fwdpp \
+gappa \
 gatb \
 gatk \
+gblocks \
+gemma \
 geneid \
 genewise \
 genome-painter \
@@ -73,6 +81,7 @@ genometools \
 gepard \
 gfakluge \
 gfalint \
+gfaview \
 gingr \
 glimmerhmm \
 gmap-gsnap \

--- a/orca-4/Dockerfile
+++ b/orca-4/Dockerfile
@@ -41,7 +41,9 @@ kraken \
 kraken2 \
 last \
 lastz \
+legsta \
 libbigwig \
+libdivsufsort \
 libmuscle \
 libpll \
 libsequence \

--- a/orca-5/Dockerfile
+++ b/orca-5/Dockerfile
@@ -13,6 +13,7 @@ man-db \
 mapsembler2 \
 maq \
 mash \
+masurca \
 maxbin2 \
 mcl \
 megahit \
@@ -28,6 +29,7 @@ minimap2 \
 mir-prefer \
 mitofy \
 mlst \
+mmtf-cpp \
 mosdepth \
 mothur \
 mp-est \
@@ -42,11 +44,14 @@ ncl \
 newick-utils \
 newicktools \
 nextflow \
+nextgenmap \
+ngmaster \
 nonpareil \
 novoalign \
 ntcard \
 ntedit \
 nthits \
+nxrepair \
 nxtrim \
 oases \
 oma \
@@ -56,6 +61,7 @@ paml \
 pandaseq \
 panito \
 parallel \
+parasail \
 parsnp \
 pathd8 \
 pathvisio \
@@ -63,6 +69,7 @@ pcre \
 pear \
 phipack \
 phlawd \
+phylip \
 phyml \
 phyutility \
 phyx \
@@ -80,4 +87,6 @@ prank \
 prodigal \
 prokka \
 proteinortho \
-psmc
+psmc \
+pullseq \
+pymol

--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -6,6 +6,7 @@ quast \
 quest \
 quickmerge \
 quicktree \
+quip \
 quorum \
 r8s \
 racon \
@@ -21,6 +22,7 @@ readseq \
 readsim \
 realphy \
 recon \
+repaq \
 repeatmasker \
 repeatmodeler \
 repeatscout \
@@ -28,6 +30,7 @@ rmblast \
 rna-star \
 rnammer \
 rtg-tools \
+salmid \
 salmon \
 sambamba \
 samblaster \
@@ -46,6 +49,7 @@ shovill \
 shrimp \
 sickle \
 simulate-pcr \
+ska \
 skesa \
 skewer \
 smalt \
@@ -66,12 +70,15 @@ squeakr \
 squeezambler \
 sratoolkit \
 ssake \
+staden-io-lib \
 stringtie \
 sumaclust \
 swarm \
+swipe \
 szip \
 tagdust \
 tasr \
+taxonkit \
 tbb \
 tbl2asn \
 tigmint \
@@ -87,6 +94,7 @@ trimmomatic \
 trinity \
 trnascan \
 unicycler \
+unikmer \
 uniqtag \
 uproc \
 vague \
@@ -103,4 +111,7 @@ vsearch \
 vt \
 weblogo \
 wiggletools \
+wtdbg2 \
+xmatchview \
+xssp \
 yaha


### PR DESCRIPTION
- Includes BTL tools: arks, xmatchview
- Removed amos (due to installation issues)
- Adding in tools in brewsci/bio that were not yet in ORCA