### PR TITLE
Temporarily remove pymol from ORCA

### DIFF
--- a/orca-5/Dockerfile
+++ b/orca-5/Dockerfile
@@ -87,5 +87,4 @@ prodigal \
 prokka \
 proteinortho \
 psmc \
-pullseq \
-pymol
+pullseq


### PR DESCRIPTION
- Due to known issue with installing 'qt' (dependency of pymol)