### PR TITLE
Use fully-qualified name for wiggletools

### DIFF
--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -110,7 +110,7 @@ viennarna \
 vsearch \
 vt \
 weblogo \
-wiggletools \
+brewsci/bio/wiggletools \
 wtdbg2 \
 xmatchview \
 xssp \


### PR DESCRIPTION
* Build failed due to finding wiggletools in brewsci/bio and brewsci/science