### PR TITLE
Remove readseq from ORCA

### DIFF
--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -18,7 +18,6 @@ raxml-ng \
 ray \
 rcorrector \
 readline \
-readseq \
 readsim \
 realphy \
 recon \


### PR DESCRIPTION
- JAR file fails to download