### PR TITLE
Revert "Use fully-qualified name for wiggletools"

### DIFF
--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -109,7 +109,7 @@ viennarna \
 vsearch \
 vt \
 weblogo \
-brewsci/bio/wiggletools \
+wiggletools \
 wtdbg2 \
 xmatchview \
 xssp \


### PR DESCRIPTION
Reverts bcgsc/orca#86