### PR TITLE
Fixes for orca-6 Docker build

### DIFF
--- a/orca-4/Dockerfile
+++ b/orca-4/Dockerfile
@@ -43,7 +43,6 @@ last \
 lastz \
 legsta \
 libbigwig \
-libdivsufsort \
 libmuscle \
 libpll \
 libsequence \

--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -2,6 +2,10 @@ FROM bcgsc/orca-5:latest
 LABEL maintainer="sjackan@gmail.com" name="bcgsc/orca-6"
 
 RUN brew update \
+&& brew uninstall vim \
+&& brew uninstall ruby \
+&& brew uninstall libbigwig \
+&& brew uninstall libdivsufsort \
 && brew install \
 quast \
 quest \
@@ -109,9 +113,9 @@ verticalize \
 viennarna \
 vsearch \
 vt \
-weblogo \
 wiggletools \
 wtdbg2 \
 xmatchview \
 xssp \
-yaha
+yaha \
+vim


### PR DESCRIPTION
* Remove libdivsufsort, do temporary uninstall
* Temporary uninstall of ruby
* Remove brewsci/science/weblogo (linking error)
* Temporary uninstall of libbigwig (Was migrated to brewsci/bio since orca-4 build)