### PR TITLE
Temporarily add `brew update quicktree`

### DIFF
--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -6,11 +6,11 @@ RUN brew update \
 && brew uninstall ruby \
 && brew uninstall libbigwig \
 && brew uninstall libdivsufsort \
+&& brew update quicktree \
 && brew install \
 quast \
 quest \
 quickmerge \
-quicktree \
 quip \
 quorum \
 r8s \


### PR DESCRIPTION
* quicktree was installed in `orca-5` as a dependency of phlawd
* Version was updated since that image build, leading to error in `orca-6` build