### PR TITLE
Updated files for ORCA

### DIFF
--- a/orca-0/Dockerfile
+++ b/orca-0/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxbrew/brew:2.0.5
+FROM linuxbrew/brew:2.1.10
 LABEL maintainer="sjackman@gmail.com" name="bcgsc/orca-0"
 
 ENV HOMEBREW_NO_AUTO_UPDATE=1
@@ -19,8 +19,7 @@ automake \
 berkeley-db \
 cpanm \
 expat \
-jdk \
-jdk@8 \
+adoptopenjdk \
 less \
 libxml2 \
 man-db \

--- a/orca-1/Dockerfile
+++ b/orca-1/Dockerfile
@@ -25,8 +25,8 @@ RUN Rscript -e 'install.packages(repos = c(CRAN = "https://cran.rstudio.com"), c
 "ggplot2", \
 "knitr", \
 "rmarkdown", \
-"tidyverse")); \
-source("https://bioconductor.org/biocLite.R"); biocLite()'
+"tidyverse", \
+"BiocManager")); BiocManager::install()'
 
 # Install Ruby packages
 RUN gem install \

--- a/orca-2/Dockerfile
+++ b/orca-2/Dockerfile
@@ -13,6 +13,7 @@ adapterremoval \
 afra \
 ale \
 andi \
+apbspdb2pqr \
 aragorn \
 arcs \
 arks \

--- a/orca-3/Dockerfile
+++ b/orca-3/Dockerfile
@@ -47,6 +47,7 @@ fasta \
 fastani \
 fastml \
 fastp \
+fastq-pair \
 fastq-tools \
 fastqc \
 fasttree \

--- a/orca-5/Dockerfile
+++ b/orca-5/Dockerfile
@@ -17,12 +17,14 @@ maxbin2 \
 mcl \
 megahit \
 meme \
+metabat \
 metaphlan \
 methpipe \
 mhap \
 minced \
 minia \
 miniasm \
+minigraph \
 minimap \
 minimap2 \
 mir-prefer \
@@ -45,6 +47,7 @@ newicktools \
 nextflow \
 nextgenmap \
 ngmaster \
+ngmerge \
 nonpareil \
 novoalign \
 ntcard \
@@ -68,7 +71,6 @@ pcre \
 pear \
 phipack \
 phlawd \
-phylip \
 phyml \
 phyutility \
 phyx \
@@ -82,6 +84,7 @@ plink \
 poa \
 porechop \
 portcullis \
+pplacer \
 prank \
 prodigal \
 prokka \

--- a/orca-6/Dockerfile
+++ b/orca-6/Dockerfile
@@ -109,6 +109,7 @@ viennarna \
 vsearch \
 vt \
 wiggletools \
+wish \
 wtdbg2 \
 xmatchview \
 xssp \


### PR DESCRIPTION
* Updated to latest version of Homebrew (2.1.10)
* Using new method to install `Bioconductor`
* Replaced `jdk` and `jdk@8` with `adoptopenjdk`
* Added tools from brewsci/bio that were not yet included in ORCA
* Removed `phylip` due to installation issues