### PR TITLE
New build fixes, upgrades, uninstalls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 RUN brew update \
-&& brew tap brewsci/base \
-&& brew tap brewsci/bio \
-&& brew tap brewsci/science \
 && brew upgrade \
 squeakr \
 xssp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,26 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>" \
       org.label-schema.url="http://www.bcgsc.ca/services/orca" \
       org.label-schema.vcs-url="https://github.com/bcgsc/orca" \
       org.label-schema.vendor="BC Cancer Genome Sciences Centre"
+
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends libfontconfig1 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN brew update \
+&& brew tap brewsci/base \
+&& brew tap brewsci/bio \
+&& brew tap brewsci/science \
+&& brew upgrade \
+squeakr \
+xssp
+
+RUN brew reinstall --build-from-source \
+gmap-gsnap \
+meme \
+nextgenmap \
+repeatmasker
+
+RUN brew uninstall \
+apbspdb2pqr \
+swig \
+nxrepair

--- a/docker.test.yml
+++ b/docker.test.yml
@@ -8,10 +8,10 @@ sut:
       brew doctor
       brew tests
       failed=0
-      for i in $$(brew list | egrep -vx 'emacs|jdk|jdk@8|kat|magic-blast|matplotlib|numpy|openjdk|portcullis|protobuf|scipy|swi-prolog|tbl2asn'); do
+      for i in $$(brew list | egrep -vx 'adoptopenjdk|emacs|jdk|jdk@8|kat|magic-blast|matplotlib|numpy|openjdk|portcullis|protobuf|scipy|swi-prolog|tbl2asn'); do
         brew linkage --test $$i || failed=1
       done
-      for i in $$(brew list | egrep -vx 'apache-spark|exabayes|idba|igv|mrbayes|nonpareil|pigz|raxml-ng|ropebwt2|ruby|treepl|trinity|unicycler|valgrind|wiggletools'); do
+      for i in $$(brew list | egrep -vx 'apache-spark|exabayes|idba|igv|mrbayes|mysql@5.7|nonpareil|pigz|raxml-ng|ropebwt2|ruby|treepl|trinity|unicycler|valgrind|wiggletools'); do
         brew test $$i 2>&1 | tee test.log
         if grep -qx 'Error: .*: failed' test.log; then
           failed=1


### PR DESCRIPTION
* skip `brew linkage --test` for `adoptopenjdk`
* skip `brew test` for `mysql@5.7`
* upgrade `xssp` and `squeakr`
* install `libfontconfig1` for `fastqc`
* install from source `gmap-gsnap`, `meme`, `nextgenmap`, `repeatmasker`
* remove `nxrepair`, `apbspdb2pqr`, `swig` from build