### PR TITLE
Build fix: changing reinstall method in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,17 @@ RUN brew update \
 squeakr \
 xssp
 
-RUN brew reinstall --build-from-source \
+RUN brew uninstall --ignore-dependencies \
+apbspdb2pqr \
+swig \
+nxrepair \
 gmap-gsnap \
 meme \
 nextgenmap \
 repeatmasker
 
-RUN brew uninstall \
-apbspdb2pqr \
-swig \
-nxrepair
+RUN brew install --build-from-source \
+gmap-gsnap \
+meme \
+nextgenmap \
+repeatmasker


### PR DESCRIPTION
Addressing this error in the build from DockerHub:
```
Step 5/6 : RUN brew reinstall --build-from-source gmap-gsnap meme nextgenmap repeatmasker
---> Running in 3c02a204c299
Error: Invalid cross-device link @ rb_file_s_rename - (/home/linuxbrew/.linuxbrew/Cellar/gmap-gsnap/2019-06-10, /home/linuxbrew/.linuxbrew/Cellar/gmap-gsnap/2019-06-10.reinstall)
```